### PR TITLE
set Stamen (URL and attribution) as default base layer for map widgets

### DIFF
--- a/ckanext/mapviews/theme/public/navigablemap.js
+++ b/ckanext/mapviews/theme/public/navigablemap.js
@@ -54,12 +54,9 @@ this.ckan.views.mapviews.navigablemap = (function () {
   }
 
   function _addBaseLayer(map) {
-    var attribution = 'Map data &copy; OpenStreetMap contributors, Tiles ' +
-                      'Courtesy of <a href="http://www.mapquest.com/"' +
-                      'target="_blank">MapQuest</a> <img' +
-                      'src="//developer.mapquest.com/content/osm/mq_logo.png">';
+      var attribution = 'Map tiles by <a href="http://stamen.com">Stamen Design</a> (<a href="http://creativecommons.org/licenses/by/3.0">CC BY 3.0</a>). Data by <a href="http://openstreetmap.org">OpenStreetMap</a> (<a href="http://creativecommons.org/licenses/by-sa/3.0">CC BY SA</a>)';      
 
-    return L.tileLayer('http://otile{s}.mqcdn.com/tiles/1.0.0/osm/{z}/{x}/{y}.png', {
+    return L.tileLayer('https://stamen-tiles-{s}.a.ssl.fastly.net/terrain/{z}/{x}/{y}.png', {
       subdomains: '1234',
       attribution: attribution
     }).addTo(map);


### PR DESCRIPTION
This commit only sets the default base layer for maps to be Stamen's (with its attribution). 